### PR TITLE
feat: 전국 관광지 데이터 및 리뷰키워드 저장

### DIFF
--- a/recommendation-final-sep-1.py
+++ b/recommendation-final-sep-1.py
@@ -3,11 +3,6 @@
 
 # In[1]:
 
-
-import pandas as pd
-import glob
-import seaborn as sns
-import matplotlib.pyplot as plt
 get_ipython().run_line_magic('matplotlib', 'inline')
 
 import matplotlib.font_manager as fm
@@ -15,171 +10,179 @@ import matplotlib.font_manager as fm
 
 # In[2]:
 
+from flask import Flask, jsonify, Response
+import pandas as pd
+import requests
+import math
+import json
+import random
+import pickle
 
-restaurants = pd.read_csv('./pre_complete.csv')
-restaurants = restaurants.transpose()
+seoul_codes=["11110","11140","11170", "11200", "11215", "11230",
+           "11260", "11290", "11305", "11320", "11350", "11380",
+           "11410", "11440", "11470", "11500", "11530", "11545",
+           "11560", "11590", "11620", "11650", "11680", "11710", "11740"] # 11
 
+busan_codes=["26110", "26140", "26170", "26200", "26230", "26260",
+             "26290", "26320", "26350", "26380", "26410", "26440",
+             "26470", "26500", "26530", "26710"] # 26
 
-# In[3]:
+daegu_codes=["27110", "27140", "27170", "27200", "27230", "27260",
+             "27290", "27710", "27720"] #27
 
+incheon_codes=["28110", "28140", "28177", "28185", "28200", "28237",
+               "28245", "28260", "28710", "28720"] #28
 
-restaurants.columns = restaurants.iloc[0]
+gwangju_codes=["29110", "29140", "29155", "29170", "29200"] #29
 
-
-# In[4]:
-
-
-restaurants.columns.name = None
-
-
-# In[5]:
-
-
-# 첫 번째 열의 내용에서 'index'와 그 뒤에 오는 숫자만 추출하여 새로운 인덱스로 설정
-restaurants.index.name = '관광타입'
-
-
-# ## 장소 이름 분석
-
-# In[6]:
-
-
-names = list(restaurants['음식점명'])
-
-
-# In[7]:
-
-
-address = list(restaurants['주소'])
-
-
-# In[8]:
-
-
-names=pd.DataFrame(names)
-address = pd.DataFrame(address)
-
-
-# In[9]:
-
-
-names.rename_axis('Id', inplace=True)
-address.rename_axis('id', inplace=True)
-
-
-# In[10]:
-
-
-# '친절해요' 열의 이름을 '친절도'로 변경
-names.rename(columns={0: 'name'}, inplace=True)
-address.rename(columns={0:'address'}, inplace=True)
-
-
-# In[11]:
-
-
-place_info = pd.merge(names, address, left_index=True, right_index=True)
-
-
-# In[12]:
-
-
-place_info = place_info.drop(index=0)
-
-
-# In[13]:
-
-
-place_info.to_pickle('./place_info.p')
-place_info = pd.read_pickle('./place_info.p')
-
-
-# ## 리뷰 키워드 분석
-
-# In[14]:
-
-
-# NaN을 빈 문자열로 대체
-restaurants['리뷰키워드'].fillna('없음', inplace=True)  # '리뷰키워드'는 해당 열의 이름으로 대체해주세요.
-
-
-# In[15]:
-
-
-import re
-
-
-# In[16]:
-
-
-review_keywords =restaurants['리뷰키워드'].apply(lambda x: re.sub(r'\s+', '', x))
-review_keywords = review_keywords.apply(lambda x: x.replace(".", ","))
-review_keywords = review_keywords.apply(lambda x: x.split(","))
-#review_keywords = list(review_keywords.apply(lambda x: x.split(",")))
-review_keywords
-# '리뷰키워드' 열의 값에 대해 split 적용
-#review_keywords = list(restaurants['리뷰키워드'].apply(lambda x: x.split("," | ", ")))
-#review_keywords
-
-
-# In[17]:
-
-
-flat_list = []
-for sublist in review_keywords:
-  for item in sublist:
-    flat_list.append(item)
-
-
-# In[18]:
-
-
-review_keywords_unique = pd.Series(list(set(flat_list)))
-
-
-# In[19]:
-
-
-#restaurants['리뷰키워드'] = restaurants['리뷰키워드'].str.replace(r'\s+', '')
-restaurants['리뷰키워드'] = restaurants['리뷰키워드'].str.replace('.', ',')
-
-restaurants['리뷰키워드'] = restaurants['리뷰키워드'].str.replace(r'\s+', '', regex=True)
-
-
-# In[20]:
-
-
-review_keywords_dummies = restaurants['리뷰키워드'].str.get_dummies(sep=',')
-
-
-# In[21]:
-
-
-review_keywords_dummies.to_pickle('./reviews.p')
-review_keywords = pd.read_pickle('./reviews.p')
-
-
-# In[22]:
-
-
-restaurants['id'] = range(1, len(restaurants)+1)
-
-
-# In[23]:
-
-
-restaurants.set_index('id', inplace=True)
-
-
-# In[24]:
-
-
-review_keywords['id'] = range(1, len(review_keywords)+1)
-review_keywords.set_index('id', inplace=True)
-
-
-# In[ ]:
-
-
-review_keywords.to_pickle('./review_keywords.p')
-
+daejeon_codes=["30110", "30140", "30170", "30200", "30230"] #30
+
+ulsan_codes=["31110", "31140", "31170", "31200", "31710"] #31
+
+sejong_codes=["36110"] #36
+
+gyeonggi_codes=["41111", "41113", "41115", "41117", "41131", "41133",
+                "41135", "41150", "41171", "41173", "41192", "41194",
+                "41196", "41210", "41220", "41250", "41271", "41273",
+                "41281", "41285", "41287", "41290", "41310", "41360",
+                "41370", "41390", "41410", "41430", "41450", "41461",
+                "41463", "41465", "41480", "41500", "41550", "41570",
+                "41590", "41610", "41630", "41650", "41670", "41800",
+                "41820", "41830"] #41
+
+chungbuk_codes=["43111", "43112", "43113", "43114", "43130", "43150",
+                "43720", "43730", "43740", "43745", "43750", "43760",
+                "43770", "43800"] #43
+
+chungnam_codes=["44131", "44133", "44150", "44180", "44200", "44210",
+                "44230", "44250", "44270", "44710", "44760", "44770",
+                "44790", "44800", "44810", "44825"] # 44
+
+jeonnam_codes=["46110", "46130", "46150", "46170", "46230", "46710",
+               "46720", "46730", "46770", "46780", "46790", "46800",
+               "46810", "46820", "46830", "46840", "46860", "46870",
+               "46880", "46890", "46900", "46910"] # 46
+
+gyeongbuk_codes=["47111", "47113", "47130", "47150", "47170", "47190",
+                 "47210", "47230", "47250", "47280", "47290", "47730",
+                 "47750", "47760", "47770", "47820", "47830", "47840",
+                 "47850", "47900", "47920", "47930", "47940"] # 47
+
+gyeongnam_codes=["48121", "48123", "48125", "48127", "48129", "48170",
+                 "48220", "48240", "48250", "48270", "48310", "48330",
+                 "48720", "48730", "48740", "48820", "48840", "48850",
+                 "48860", "48870", "48880", "48890"] # 48
+
+jeju_codes=["50110", "50130"] # 50
+
+gangwon_codes=["51110", "51130", "51150", "51170", "51190", "51210",
+               "51230", "51720", "51730", "51750", "51760", "51770",
+               "51780", "51790", "51800", "51810", "51820", "51830"] # 51
+
+jeonbuk_codes=["52111", "52113", "52130", "52140", "52180", "52190",
+               "52210", "52710", "52720", "52730", "52740", "52750",
+               "52770", "52790", "52800"] # 52
+
+
+app = Flask(__name__)
+
+API_URL="http://apis.data.go.kr/B551011/TarRlteTarService1/areaBasedList1"
+SERVICE_KEY="41fd329d3da1b3a48fa07d3f2a01696145aa2d63d0e9294fe5f28dff30b7716d"
+
+numOfRows=1000
+
+params = {
+    "serviceKey": SERVICE_KEY,
+    "pageNo": 1,
+    "numOfRows": 1,
+    "MobileOS": "WEB",
+    "MobileApp": "travel-application",
+    "baseYm": "202506",
+    "_type": "json"
+}
+
+areaCd="52"
+
+all_dataframes=[]
+
+for sigungu_code in jeonbuk_codes:
+    params.update({
+        "areaCd": areaCd,
+        "signguCd": sigungu_code,
+        "pageNo": 1,
+        "numOfRows": 1
+
+    })
+    res = requests.get(API_URL, params=params).json()
+    total_count = res["response"]["body"]["totalCount"]
+
+    if total_count==0:
+        print(f"데이터 없음: 시군구 코드 {sigungu_code}")
+        continue
+
+    total_pages=math.ceil(total_count/numOfRows)
+
+    for page in range(1, total_pages+1):
+        params.update({
+            "pageNo": page,
+            "numOfRows": numOfRows
+        })
+
+        res=requests.get(API_URL, params=params).json()
+        places=res["response"]["body"]["items"]["item"]
+
+        selected_columns=[
+            {
+                "tAtsCd": place["tAtsCd"],
+                "tAtsNm": place["tAtsNm"],
+                "areaCd": place["areaCd"],
+                "areaNm": place["areaNm"],
+                "signguCd": place["signguCd"],
+                "signguNm": place["signguNm"],
+                "rlteTatsCd": place["rlteTatsCd"],
+                "rlteTatsNm": place["rlteTatsNm"],
+                "rlteRegnCd": place["rlteRegnCd"],
+                "rlteRegnNm": place["rlteRegnNm"],
+                "rlteSignguCd": place["rlteSignguCd"],
+                "rlteSignguNm": place["rlteSignguNm"],
+                "rlteCtgryLclsNm": place["rlteCtgryLclsNm"],
+                "rlteCtgryMclsNm": place["rlteCtgryMclsNm"],
+                "rlteCtgrySclsNm": place["rlteCtgrySclsNm"],
+                "rlteRank": place["rlteRank"]
+            }
+            for place in places
+        ]
+
+        df=pd.DataFrame(selected_columns)
+        all_dataframes.append(df)
+
+final_df=pd.concat(all_dataframes, ignore_index=True)
+
+final_df.to_pickle("jeonbuk_data.pkl")
+
+if __name__ == "__main__":
+    app.run(debug=True)
+
+
+files=["seoul_data.pkl", "busan_data.pkl", "daegu_data.pkl", "incheon_data.pkl",
+       "gwangju_data.pkl", "daejeon_data.pkl", "ulsan_data.pkl", "sejong_data.pkl",
+       "gyeonggi_data.pkl", "chungbuk_data.pkl", "chungnam_data.pkl", "jeonnam_data.pkl",
+       "gyeongbuk_data.pkl", "gyeongnam_data.pkl", "jeju_data.pkl", "gangwon_data.pkl", "jeonbuk_data.pkl"]
+
+dfs=[pd.read_pickle(file) for file in files]
+df_total=pd.concat(dfs, ignore_index=True)
+
+review_keywords=["직원이 친절해요", "경치가 좋아요",
+                 "포토스팟이 많아요", "동선이 잘 짜였어요",
+                 "시설이 깨끗해요", "접근성이 좋아요",
+                 "아이와 함께 가기 좋아요", "한적하고 여유로워요",
+                 "가성비가 좋아요", "전시/인테리어 연출이 멋져요"]
+
+df_total["리뷰키워드"]=df_total.apply(
+    lambda row: random.sample(review_keywords, 5), axis=1
+)
+
+df_total.to_pickle("places_data.pkl")
+
+with open("review_keywords.pkl", "wb") as f:
+    pickle.dump(review_keywords, f)


### PR DESCRIPTION
## #️⃣ 연관 이슈

- #14 

### 🎯 PR 개요

- 공공데이터포털의 관광지별 연관 관광지 정보 API를 통해 전국 관광지 데이터를 저장했습니다.

### 📑 작업 내용

- 공공데이터포털에서 전국 관광지 정보를 API로 요쳥하여 `places_data.pkl`로 저장했습니다.
- 리뷰 키워드 칼럼을 추가하고, 모든 관광지 데이터에 무작위로 선택한 5개의 리뷰 키워드를 추가했습니다.
- 10개의 리뷰 키워드를 `review_keywords.pkl`로 저장했습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.