### PR TITLE
feat: 폼 로그인 추가

### DIFF
--- a/src/main/java/travel/travelapplication/auth/config/BCryptConfig.java
+++ b/src/main/java/travel/travelapplication/auth/config/BCryptConfig.java
@@ -1,0 +1,14 @@
+package travel.travelapplication.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class BCryptConfig {
+
+  @Bean
+  public BCryptPasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/travel/travelapplication/auth/config/SecurityConfig.java
+++ b/src/main/java/travel/travelapplication/auth/config/SecurityConfig.java
@@ -28,6 +28,13 @@ public class SecurityConfig {
                 .requestMatchers("/admin/**").hasAnyRole("ADMIN")
                 .anyRequest().permitAll()
         )
+        .formLogin((formLoginConfigurer) ->
+            formLoginConfigurer.usernameParameter("email")
+                .passwordParameter("password")
+                .loginPage("/loginForm")
+                .loginProcessingUrl("/login")
+                .defaultSuccessUrl("/home")
+        )
         .oauth2Login((oauth2Login) ->
             oauth2Login
                 .loginPage("/loginForm")

--- a/src/main/java/travel/travelapplication/auth/dto/JoinRequest.java
+++ b/src/main/java/travel/travelapplication/auth/dto/JoinRequest.java
@@ -1,0 +1,31 @@
+package travel.travelapplication.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import travel.travelapplication.auth.constant.Role;
+import travel.travelapplication.user.domain.User;
+
+public record JoinRequest(
+    @NotBlank(message = "이름은 필수입니다.")
+    String name,
+
+    @Email(message = "올바른 이메일 형식을 입력해주세요.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    String email,
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    String password,
+
+    @NotBlank(message = "이메일 확인은 필수입니다.")
+    String checkPassword
+) {
+
+  public User toEntity(String encodedPassword) {
+    return User.builder()
+        .name(this.name)
+        .email(this.email)
+        .password(encodedPassword)
+        .role(Role.USER.getKey())
+        .build();
+  }
+}

--- a/src/main/java/travel/travelapplication/auth/dto/OAuthAttributes.java
+++ b/src/main/java/travel/travelapplication/auth/dto/OAuthAttributes.java
@@ -3,7 +3,6 @@ package travel.travelapplication.auth.dto;
 import lombok.Builder;
 import lombok.Getter;
 import travel.travelapplication.auth.constant.Role;
-import travel.travelapplication.user.domain.User;
 
 import java.util.Map;
 
@@ -41,6 +40,7 @@ public class OAuthAttributes {
     return OAuthAttributes.builder()
         .name((String) attributes.get("name"))
         .email((String) attributes.get("email"))
+        .attributes(attributes)
         .nameAttributeKey(userNameAttributeName)
         .build();
   }
@@ -55,9 +55,5 @@ public class OAuthAttributes {
         .attributes(response)
         .nameAttributeKey(userNameAttributeName)
         .build();
-  }
-
-  public User toEntity(String role, String accessToken) { // 수정하기
-    return new User(name, email, null, null, null, null, role, accessToken);
   }
 }

--- a/src/main/java/travel/travelapplication/auth/dto/PrincipalDetails.java
+++ b/src/main/java/travel/travelapplication/auth/dto/PrincipalDetails.java
@@ -1,0 +1,72 @@
+package travel.travelapplication.auth.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import travel.travelapplication.user.domain.User;
+
+public class PrincipalDetails implements UserDetails, OAuth2User {
+
+  private User user;
+  private Map<String, Object> attributes;
+
+  public PrincipalDetails(User user) {
+    this.user = user;
+  }
+
+  public PrincipalDetails(User user, Map<String, Object> attributes) {
+    this.user = user;
+    this.attributes = attributes;
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    Collection<GrantedAuthority> collections = new ArrayList<>();
+    collections.add(() -> user.getRole());
+
+    return collections;
+  }
+
+  @Override
+  public String getPassword() {
+    return user.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return user.getEmail();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+}

--- a/src/main/java/travel/travelapplication/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/travel/travelapplication/auth/service/CustomOAuth2UserService.java
@@ -1,18 +1,16 @@
 package travel.travelapplication.auth.service;
 
-import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import travel.travelapplication.auth.CustomOAuth2User;
 import travel.travelapplication.auth.constant.Role;
 import travel.travelapplication.auth.dto.OAuthAttributes;
+import travel.travelapplication.auth.dto.PrincipalDetails;
 import travel.travelapplication.auth.exception.PrincipalNameEmptyException;
 import travel.travelapplication.user.domain.User;
 import travel.travelapplication.user.repository.UserRepository;
@@ -51,15 +49,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
       throw new PrincipalNameEmptyException();
     }
 
-    return new CustomOAuth2User(
-        Collections.singleton(new SimpleGrantedAuthority(findUser.getRole())),
-        oAuth2User.getAttributes(),
-        attributes.getNameAttributeKey(),
-        findUser.getEmail(),
-        findUser.getName(),
-        findUser.getRole(),
-        registrationId
-    );
+    return new PrincipalDetails(findUser, oAuth2User.getAttributes());
   }
 
   private User saveUser(OAuthAttributes attributes, String role, String accessToken) {

--- a/src/main/java/travel/travelapplication/auth/service/PrincipalDetailsService.java
+++ b/src/main/java/travel/travelapplication/auth/service/PrincipalDetailsService.java
@@ -1,0 +1,25 @@
+package travel.travelapplication.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+import travel.travelapplication.auth.dto.PrincipalDetails;
+import travel.travelapplication.user.domain.User;
+import travel.travelapplication.user.exception.UserNotFoundException;
+import travel.travelapplication.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UserNotFoundException {
+    User user = userRepository.findByEmail(username)
+        .orElseThrow(UserNotFoundException::new);
+
+    return new PrincipalDetails(user);
+  }
+}

--- a/src/main/java/travel/travelapplication/exception/ErrorCode.java
+++ b/src/main/java/travel/travelapplication/exception/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
   CITY_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE002", "해당 도시를 찾을 수 없습니다."),
 
   // Tag
-  INVALID_TAG_SELECTION(HttpStatus.BAD_REQUEST, "TAG001","태그 선택이 유효하지 않습니다."),
+  INVALID_TAG_SELECTION(HttpStatus.BAD_REQUEST, "TAG001", "태그 선택이 유효하지 않습니다."),
 
   // Plan
   PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN001", "Plan이 없습니다."),
@@ -29,6 +29,11 @@ public enum ErrorCode {
   // User
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER001", "사용자를 찾을 수 없습니다."),
   USER_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "USER002", "인증되지 않은 사용자입니다. 로그인하세요."),
+  USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER003", "이미 가입한 사용자입니다."),
+  NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER004", "이미 존재하는 사용자 이름입니다."),
+  EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER005", "이미 존재하는 이메일입니다."),
+  PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "USER006", "비밀번호가 일치하지 않습니다."),
+
 
   // UserPlan
   SAVED_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_PLAN001", "SavedPlan이 없습니다."),

--- a/src/main/java/travel/travelapplication/user/application/UserService.java
+++ b/src/main/java/travel/travelapplication/user/application/UserService.java
@@ -6,8 +6,11 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import travel.travelapplication.auth.CustomOAuth2User;
+import travel.travelapplication.auth.dto.JoinRequest;
+import travel.travelapplication.exception.ErrorCode;
 import travel.travelapplication.place.domain.Tag;
 import travel.travelapplication.place.dto.TagListResponse;
 import travel.travelapplication.place.exception.InvalidTagSelectionException;
@@ -15,6 +18,8 @@ import travel.travelapplication.place.repository.TagRepository;
 import travel.travelapplication.plan.domain.Plan;
 import travel.travelapplication.user.domain.User;
 import travel.travelapplication.user.dto.UserResponse;
+import travel.travelapplication.user.exception.DuplicateResourceException;
+import travel.travelapplication.user.exception.PasswordValidationException;
 import travel.travelapplication.user.exception.UserNotAuthorizedException;
 import travel.travelapplication.user.exception.UserNotFoundException;
 import travel.travelapplication.user.repository.UserRepository;
@@ -27,9 +32,48 @@ public class UserService {
 
   private final UserRepository userRepository;
   private final TagRepository tagRepository;
+  private final BCryptPasswordEncoder encoder;
 
   public void save(User user) {
     userRepository.save(user);
+  }
+
+  public UserResponse join(JoinRequest joinRequest) {
+    if (checkNameDuplicate(joinRequest.name())) {
+      throw new DuplicateResourceException(ErrorCode.NAME_ALREADY_EXISTS);
+    }
+
+    if (checkEmailDuplicate(joinRequest.email())) {
+      throw new DuplicateResourceException(ErrorCode.EMAIL_ALREADY_EXISTS);
+    }
+
+    if (checkPasswordMatch(joinRequest.password(), joinRequest.checkPassword())) {
+      throw new PasswordValidationException();
+    }
+
+    checkUserDuplicate(joinRequest.toEntity(encoder.encode(joinRequest.password())));
+    User user = userRepository.save(joinRequest.toEntity(encoder.encode(joinRequest.password())));
+
+    return UserResponse.fromEntity(user);
+  }
+
+  private void checkUserDuplicate(User user) {
+    userRepository.findByEmail(user.getEmail())
+        .ifPresent(m -> {
+          throw new DuplicateResourceException(ErrorCode.USER_ALREADY_EXISTS);
+        });
+  }
+
+  private boolean checkNameDuplicate(String username) {
+    return userRepository.existsByName(username);
+  }
+
+  private boolean checkEmailDuplicate(String email) {
+    return userRepository.findByEmail(email).isEmpty();
+  }
+
+  private boolean checkPasswordMatch(String password, String checkPassword) {
+    return password.equals(checkPassword);
   }
 
   public void updateUserName(User user, String username) {

--- a/src/main/java/travel/travelapplication/user/domain/User.java
+++ b/src/main/java/travel/travelapplication/user/domain/User.java
@@ -26,6 +26,8 @@ public class User {
 
   private String email;
 
+  private String password;
+
   private String role;
 
   @DBRef
@@ -49,10 +51,11 @@ public class User {
 
   @PersistenceCreator
   @Builder
-  public User(String name, String email, List<UserPlan> userPlans, List<Tag> tags,
+  public User(String name, String email, String password, List<UserPlan> userPlans, List<Tag> tags,
       List<Long> likedPlaces, List<Plan> savedPlans, String role, String accessToken) {
     this.name = name;
     this.email = email;
+    this.password=password;
     this.userPlans = userPlans;
     this.tags = tags;
     this.likedPlaces = likedPlaces;

--- a/src/main/java/travel/travelapplication/user/exception/DuplicateResourceException.java
+++ b/src/main/java/travel/travelapplication/user/exception/DuplicateResourceException.java
@@ -1,0 +1,11 @@
+package travel.travelapplication.user.exception;
+
+import travel.travelapplication.exception.ErrorCode;
+import travel.travelapplication.exception.TravelException;
+
+public class DuplicateResourceException extends TravelException {
+
+  public DuplicateResourceException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/travel/travelapplication/user/exception/PasswordValidationException.java
+++ b/src/main/java/travel/travelapplication/user/exception/PasswordValidationException.java
@@ -1,0 +1,11 @@
+package travel.travelapplication.user.exception;
+
+import travel.travelapplication.exception.ErrorCode;
+import travel.travelapplication.exception.TravelException;
+
+public class PasswordValidationException extends TravelException {
+
+  public PasswordValidationException() {
+    super(ErrorCode.PASSWORD_MISMATCH);
+  }
+}

--- a/src/main/java/travel/travelapplication/user/presentation/UserController.java
+++ b/src/main/java/travel/travelapplication/user/presentation/UserController.java
@@ -1,5 +1,6 @@
 package travel.travelapplication.user.presentation;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -7,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import travel.travelapplication.auth.CustomOAuth2User;
+import travel.travelapplication.auth.dto.JoinRequest;
 import travel.travelapplication.user.application.UserService;
 import travel.travelapplication.user.domain.User;
 import travel.travelapplication.user.dto.UserResponse;
@@ -19,6 +21,13 @@ import travel.travelapplication.userplan.dto.UserPlanListItemResponse;
 public class UserController {
 
   private final UserService userService;
+
+  @PostMapping("/join")
+  public ResponseEntity<UserResponse> join(@Valid @RequestBody JoinRequest joinRequest) {
+    UserResponse userResponse = userService.join(joinRequest);
+
+    return ResponseEntity.ok(userResponse);
+  }
 
   @GetMapping
   public String profile() {

--- a/src/main/java/travel/travelapplication/user/repository/UserRepository.java
+++ b/src/main/java/travel/travelapplication/user/repository/UserRepository.java
@@ -9,5 +9,7 @@ import java.util.Optional;
 public interface UserRepository extends MongoRepository<User, ObjectId> {
     Optional<User> findByEmail(String email);
 
+    boolean existsByName(String name);
+
     Optional<User> findByRefreshToken(String refreshToken);
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈

- #19 

### 🎯 PR 개요

- 폼 로그인 기능 추가

### 📑 작업 내용

- 로그인을 요청한 사용자의 정보를 받아오는 `PrincipalDetails`를 추가로 생성했습니다.
  - 소셜 로그인, 폼 로그인을 요청한 사용자의 정보를 동일한 클래스에서 받을 수 있도록 통일했습니다.
  - 따라서 기존의 `CustomOAuth2User`를 제거하는 것에 대해 상의하면 좋겠습니다!
- 로그인 정보와 관련하여 Validation과 예외 처리를 추가했습니다.
- 비밀번호를 암호화하여 저장할 수 있도록 PasswordEncoder를 추가했습니다.

### 💬리뷰 요구사항

- 사용자 이메일이나 닉네임에 대해 중복 발생 시, `DuplicateResourceException` 예외를 동일하게 활용하고 에러 코드로 구분을 주었는데, 이메일, 닉네임 중복에 대한 예외를 따로따로 생성하는 것이 좋은지 의견 부탁드립니다 😊

### ✅ PR 올리기 전 체크리스트

- [ ] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [ ] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.